### PR TITLE
Lambda Interpreter

### DIFF
--- a/LambdaInterpreter.Tests/LambdaInterpreter.Tests.fsproj
+++ b/LambdaInterpreter.Tests/LambdaInterpreter.Tests.fsproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="LambdaInterpreterTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FsUnit" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LambdaInterpreter\LambdaInterpreter.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/LambdaInterpreter.Tests/LambdaInterpreterTests.fs
+++ b/LambdaInterpreter.Tests/LambdaInterpreterTests.fs
@@ -1,0 +1,109 @@
+﻿module LambdaInterpreter.Tests
+
+open NUnit.Framework
+open FsUnit
+
+open LambdaInterpreter
+
+[<Test>]
+let ``getFreeVariables should return correct set for simple variable`` () =
+    let term = Variable "x"
+    let result = getFreeVariables term
+    result |> should equal (Set.ofList ["x"])
+
+[<Test>]
+let``getFreeVariables should return correct set for abstraction`` () =
+    let term = Abstraction("x", Variable "x")
+    let result = if Set.isEmpty (getFreeVariables term) then 1 else 0
+    result |> should equal 1
+
+[<Test>]
+let``getFreeVariables should return correct set for application`` () =
+    let term = Application(Variable "x", Variable "y")
+    let result = getFreeVariables term
+    result |> should equal (Set.ofList ["x"; "y"])
+
+[<Test>]
+let ``substitute should replace free variable`` () =
+    let term = Variable "x"
+    let substitution = Variable "y"
+    let result = substitute "x" substitution term
+    result |> should equal (Variable "y")
+
+let ``substitute should not replace bound variable`` () =
+    let term = Abstraction("x", Variable "x")
+    let substitution = Variable "y"
+    let result = substitute "x" substitution term
+    result |> should equal term
+
+[<Test>]
+let ``betaReduction should reduce simple application`` () =
+    let term = Application(Abstraction("x", Variable "x"), Variable "y")
+    let result = betaReduction term
+    result |> should equal (Variable "y")
+
+[<Test>]
+let ``betaReduction should handle nested applications`` () =
+    let term = Application(Abstraction("x", Application(Variable "x", Variable "y")), Variable "z")
+    let result = betaReduction term
+    result |> should equal (Application(Variable "z", Variable "y"))
+
+[<Test>]
+let ``Addition should work correctly`` () =
+    let two = Abstraction("f", 
+                Abstraction("x", 
+                    Application(Variable "f", 
+                        Application(Variable "f", Variable "x"))))
+    let three = Abstraction("f", 
+                Abstraction("x", 
+                    Application(Variable "f", 
+                        Application(Variable "f", 
+                            Application(Variable "f", Variable "x")))))
+    let five = Abstraction("f", 
+                Abstraction("x", 
+                    Application(Variable "f", 
+                        Application(Variable "f", 
+                            Application(Variable "f", 
+                                Application(Variable "f", 
+                                    Application(Variable "f", Variable "x")))))))
+    let successor = Abstraction("n",
+                    Abstraction("f",
+                    Abstraction("x", 
+                        Application(Variable "f", 
+                            Application(Application(Variable "n", Variable "f"), Variable "x")))))
+    let plus = Abstraction("m", 
+                Abstraction("n", 
+                Application(Application(Variable "m", successor), Variable "n")))
+    let pluss = Abstraction("m", 
+                Abstraction("n",
+                Abstraction("f",
+                Abstraction("x",
+                    Application(Application(Variable "m", Variable "f"), 
+                                Application(Application(Variable "n", Variable "f"), Variable "x"))))))
+    let result = betaReduction (Application(Application(plus, two), three))
+    result |> should equal five
+
+[<Test>]
+let ``Y combinator should produce fixed point`` () =
+    let yCombinator = Abstraction("f", Application(
+        Abstraction("x", Application(Variable "f", Application(Variable "x", Variable "x"))),
+        Abstraction("x", Application(Variable "f", Application(Variable "x", Variable "x")))))
+    let factorial = Abstraction("f", Abstraction("n", 
+            Application(Application(Variable "if", Application(Application(Variable "eq", Variable "n"), Variable "0")),
+                Application(Variable "1", Application(Application(Variable "mul", Variable "n"), Application(Variable "f", Application(Variable "pred", Variable "n")))))))
+    let fixedPoint = betaReduction (Application(yCombinator, factorial))
+    fixedPoint |> should not' (equal factorial)
+
+[<Test>]
+let ``Conditional operator should work correctly`` () =
+    let trueTerm = Abstraction("x", Abstraction("y", Variable "x"))
+    let ifTerm = Abstraction("b", 
+                Abstraction("t", 
+                Abstraction("f", 
+                Application(Application(Variable "b", Variable "t"), 
+                Variable "f"))))
+    let test = Application(
+                Application(Application(ifTerm, trueTerm), Variable "x"),
+                Variable "y")
+    let result = betaReduction test
+    result |> should equal (Variable "x")

--- a/LambdaInterpreter/LambdaInterpreter.fsproj
+++ b/LambdaInterpreter/LambdaInterpreter.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/LambdaInterpreter/LambdaInterpreter.sln
+++ b/LambdaInterpreter/LambdaInterpreter.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35514.174
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "LambdaInterpreter", "LambdaInterpreter.fsproj", "{79F517AE-A0F5-4278-BE4B-F93768DE3F33}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "LambdaInterpreter.Tests", "..\LambdaInterpreter.Tests\LambdaInterpreter.Tests.fsproj", "{432A4C4D-CFD3-4DBA-B764-117D4A1D8BDE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{79F517AE-A0F5-4278-BE4B-F93768DE3F33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F517AE-A0F5-4278-BE4B-F93768DE3F33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79F517AE-A0F5-4278-BE4B-F93768DE3F33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79F517AE-A0F5-4278-BE4B-F93768DE3F33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{432A4C4D-CFD3-4DBA-B764-117D4A1D8BDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{432A4C4D-CFD3-4DBA-B764-117D4A1D8BDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{432A4C4D-CFD3-4DBA-B764-117D4A1D8BDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{432A4C4D-CFD3-4DBA-B764-117D4A1D8BDE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/LambdaInterpreter/Program.fs
+++ b/LambdaInterpreter/Program.fs
@@ -80,7 +80,7 @@ let rec betaReduction lambdaTerm =
         | Application(firstTerm, secondTerm) ->
             let newFirstTerm = betaReductionStep firstTerm
             match newFirstTerm with
-            | Abstraction _ -> (newFirstTerm, betaReductionStep secondTerm) |> Application |> betaReductionStep
+            | Abstraction _ -> (newFirstTerm, secondTerm) |> Application |> betaReductionStep
             | _ -> Application(firstTerm, betaReductionStep secondTerm)
         | Abstraction(x, body) -> Abstraction(x, betaReductionStep body)
         | _ -> lambdaTerm

--- a/LambdaInterpreter/Program.fs
+++ b/LambdaInterpreter/Program.fs
@@ -1,0 +1,95 @@
+﻿module LambdaInterpreter
+
+open System
+
+type LambdaTerm =
+    | Variable of string
+    | Application of LambdaTerm * LambdaTerm
+    | Abstraction of string * LambdaTerm
+
+type ContinuationStep<'a> =
+    | Finished
+    | Step of 'a * (unit -> ContinuationStep<'a>)
+
+let rec getFreeVariables lambdaTerm =
+    let rec linearize term continuation =
+        match term with
+        | Variable x -> continuation()
+        | Application(first, second) as application -> Step(application, (fun () -> linearize first (fun () -> linearize second continuation)))
+        | Abstraction(x, body) as abstraction -> Step(abstraction, fun () -> linearize body continuation)
+    
+    let steps = linearize lambdaTerm (fun () -> Finished)
+    let rec processSteps step setAll setBounded =
+        match step with
+        | Finished -> 
+            let setFree = Set.difference setAll setBounded
+            let setFreeBounded = Set.intersect setFree setBounded
+            Set.union setFree setFreeBounded
+        | Step(x, getNext) ->
+            match x with
+            | Application(first, second) ->
+                let newSetAll = 
+                    match (first, second) with
+                    | (Variable x, Variable y) -> setAll |> Set.add x |> Set.add y
+                    | (Variable x, _) -> setAll |> Set.add x
+                    | (_, Variable y) -> setAll |> Set.add y
+                    | _ -> setAll
+                processSteps (getNext()) newSetAll setBounded
+            | Abstraction(x, body) ->
+                let newSetAll = 
+                    match body with
+                    | Variable y -> setAll |> Set.add x |> Set.add y
+                    | _ -> setAll |> Set.add x
+                processSteps (getNext()) newSetAll (setBounded |> Set.add x)
+            | _ -> failwith "Incorrect lambda term"
+
+    match lambdaTerm with
+    | Variable x -> Set.empty.Add(x)
+    | _ -> processSteps steps Set.empty Set.empty
+
+let rec generateRandomString length occupied =
+    let random = Random()
+    let chars = "abcdefghijklmnopqrstuvwxyz"
+    let charsLength = chars.Length
+    let randomChars = [| for _ in 1 .. length -> chars.[random.Next(charsLength)] |]
+
+    let result = new string(randomChars)
+    if not (Set.contains result occupied) then result else generateRandomString length occupied
+
+let rec substitute freeVariable substitutionTerm generalTerm =
+    match generalTerm with
+    | Variable x -> if freeVariable = x then substitutionTerm else generalTerm
+    | Application(firstTerm, secondTerm) -> 
+        Application(substitute freeVariable substitutionTerm firstTerm, substitute freeVariable substitutionTerm secondTerm)
+    | Abstraction(x, body) ->
+        let substitutionTermFreeVariables = getFreeVariables substitutionTerm
+        let result =
+            if freeVariable = x then generalTerm
+            elif not (Set.contains x substitutionTermFreeVariables) then 
+                Abstraction(x, substitute freeVariable substitutionTerm body)
+            else 
+                let newX = generateRandomString 2 substitutionTermFreeVariables
+                Abstraction(newX, substitute x (Variable(newX)) body |> substitute freeVariable substitutionTerm)
+        result
+
+let rec betaReduction lambdaTerm = 
+    let rec betaReductionStep lambdaTerm = 
+        match lambdaTerm with
+        | Application(Abstraction(x, body), argument) -> substitute x argument body
+        | Application(Variable x, argument) -> Application(Variable x, betaReductionStep argument)
+        | Application(firstTerm, secondTerm) ->
+            let newFirstTerm = betaReductionStep firstTerm
+            match newFirstTerm with
+            | Abstraction _ -> (newFirstTerm, betaReductionStep secondTerm) |> Application |> betaReductionStep
+            | _ -> Application(firstTerm, betaReductionStep secondTerm)
+        | Abstraction(x, body) -> Abstraction(x, betaReductionStep body)
+        | _ -> lambdaTerm
+    
+    let rec getResult lambdaTerm =
+        let reducedTerm = betaReductionStep lambdaTerm
+        if reducedTerm = lambdaTerm then
+            reducedTerm
+        else
+            getResult reducedTerm 
+
+    getResult lambdaTerm


### PR DESCRIPTION
_Реализовать интерпретатор лямбда-выражений, выполняющий бета-редукцию по нормальной стратегии. Лямбда-выражения задаются через размеченные объединения. Должна поддерживаться альфа-конверсия для избежания захвата свободных переменных._